### PR TITLE
add ct_unrealized_struct_or_union

### DIFF
--- a/src/c/_cffi_backend.c
+++ b/src/c/_cffi_backend.c
@@ -2690,7 +2690,7 @@ cdata_slice(CDataObject *cd, PySliceObject *slice)
 #ifdef Py_GIL_DISABLED
         cffi_atomic_store((void **)&ct->ct_stuff, array_type);
 #else
-        ct->ct_stuff = array_type;
+        ct->ct_stuff = (PyObject *)array_type;
 #endif
     }
     Py_END_CRITICAL_SECTION();

--- a/src/c/_cffi_backend.c
+++ b/src/c/_cffi_backend.c
@@ -646,7 +646,8 @@ force_lazy_struct(CTypeDescrObject *ct)
 static PyObject *ctypeget_fields(CTypeDescrObject *ct, void *context)
 {
     if (ct->ct_flags & (CT_STRUCT | CT_UNION)) {
-        if (!(ct->ct_flags & CT_IS_OPAQUE || cffi_check_flag(ct->ct_unrealized_struct_or_union))) {
+        assert((ct->ct_flags & CT_IS_OPAQUE) == 0);
+        if (!cffi_check_flag(ct->ct_unrealized_struct_or_union)) {
             CFieldObject *cf;
             PyObject *res;
             if (force_lazy_struct(ct) < 0)
@@ -3364,8 +3365,8 @@ static PyObject *cdata_dir(PyObject *cd, PyObject *noarg)
         ct = ct->ct_itemdescr;
     }
     if ((ct->ct_flags & (CT_STRUCT | CT_UNION)) &&
-        !((ct->ct_flags & CT_IS_OPAQUE) || cffi_check_flag(ct->ct_unrealized_struct_or_union))) {
-
+        !(cffi_check_flag(ct->ct_unrealized_struct_or_union))) {
+        assert((ct->ct_flags & CT_IS_OPAQUE) == 0);
         /* for non-opaque structs or unions */
         if (force_lazy_struct(ct) < 0)
             return NULL;
@@ -5154,7 +5155,6 @@ static PyObject *new_void_type(void)
     td->ct_size = -1;
     td->ct_flags = CT_VOID | CT_IS_OPAQUE;
     td->ct_flags_mut = 0;
-    td->ct_unrealized_struct_or_union = 1;
     td->ct_name_position = strlen("void");
     unique_key[0] = "void";
     return get_unique_type(td, unique_key, 1);
@@ -5374,8 +5374,8 @@ static PyObject *b_complete_struct_or_union(PyObject *self, PyObject *args)
             goto finally;
 
         if ((ftype->ct_flags & (CT_STRUCT | CT_UNION)) &&
-            !((ftype->ct_flags & CT_IS_OPAQUE) || cffi_check_flag(ct->ct_unrealized_struct_or_union))) {
-
+            !(cffi_check_flag(ct->ct_unrealized_struct_or_union))) {
+            assert((ftype->ct_flags & CT_IS_OPAQUE) == 0);
             /* force now the type of the nested field */
             if (force_lazy_struct(ftype) < 0)
                 goto finally;

--- a/src/c/_cffi_backend.c
+++ b/src/c/_cffi_backend.c
@@ -5152,7 +5152,7 @@ static PyObject *new_void_type(void)
 
     memcpy(td->ct_name, "void", name_size);
     td->ct_size = -1;
-    td->ct_flags = CT_VOID;
+    td->ct_flags = CT_VOID | CT_IS_OPAQUE;
     td->ct_flags_mut = 0;
     td->ct_unrealized_struct_or_union = 1;
     td->ct_name_position = strlen("void");

--- a/src/c/_cffi_backend.c
+++ b/src/c/_cffi_backend.c
@@ -320,6 +320,7 @@ typedef struct _ctypedescr {
     int ct_flags_mut;       /* Mutable flags (e.g., CT_CUSTOM_FIELD_POS) */
     uint8_t ct_under_construction;
     uint8_t ct_lazy_field_list;
+    uint8_t ct_incomplete_struct_or_union;
     int ct_name_position;   /* index in ct_name of where to put a var name */
     char ct_name[1];        /* string, e.g. "int *" for pointers to ints */
 } CTypeDescrObject;
@@ -476,6 +477,7 @@ ctypedescr_new(int name_size)
     ct->ct_unique_key = NULL;
     ct->ct_lazy_field_list = 0;
     ct->ct_under_construction = 0;
+    ct->ct_incomplete_struct_or_union = 0;
     PyObject_GC_Track(ct);
     return ct;
 }
@@ -644,7 +646,7 @@ force_lazy_struct(CTypeDescrObject *ct)
 static PyObject *ctypeget_fields(CTypeDescrObject *ct, void *context)
 {
     if (ct->ct_flags & (CT_STRUCT | CT_UNION)) {
-        if (!(ct->ct_flags & CT_IS_OPAQUE)) {
+        if (!(ct->ct_flags & CT_IS_OPAQUE || cffi_check_flag(ct->ct_incomplete_struct_or_union))) {
             CFieldObject *cf;
             PyObject *res;
             if (force_lazy_struct(ct) < 0)
@@ -1172,7 +1174,8 @@ convert_to_object(char *data, CTypeDescrObject *ct)
                          ct->ct_name);
             return NULL;
         }
-        else if (cffi_check_flag(ct->ct_under_construction)) {
+        else if (cffi_check_flag(ct->ct_under_construction) ||
+                 cffi_check_flag(ct->ct_incomplete_struct_or_union)) {
             PyErr_Format(PyExc_TypeError,
                          "'%s' is not completed yet",
                          ct->ct_name);
@@ -1955,7 +1958,7 @@ get_alignment(CTypeDescrObject *ct)
     int align;
  retry:
     if ((ct->ct_flags & (CT_PRIMITIVE_ANY|CT_STRUCT|CT_UNION)) &&
-        !(ct->ct_flags & CT_IS_OPAQUE)) {
+        !((ct->ct_flags & CT_IS_OPAQUE) || cffi_check_flag(ct->ct_incomplete_struct_or_union))) {
         // needs critical section
         align = ct->ct_length;
         if (align == -1 && cffi_check_flag(ct->ct_lazy_field_list)) {
@@ -3360,7 +3363,7 @@ static PyObject *cdata_dir(PyObject *cd, PyObject *noarg)
         ct = ct->ct_itemdescr;
     }
     if ((ct->ct_flags & (CT_STRUCT | CT_UNION)) &&
-        !(ct->ct_flags & CT_IS_OPAQUE)) {
+        !((ct->ct_flags & CT_IS_OPAQUE) || cffi_check_flag(ct->ct_incomplete_struct_or_union))) {
 
         /* for non-opaque structs or unions */
         if (force_lazy_struct(ct) < 0)
@@ -5146,8 +5149,9 @@ static PyObject *new_void_type(void)
 
     memcpy(td->ct_name, "void", name_size);
     td->ct_size = -1;
-    td->ct_flags = CT_VOID | CT_IS_OPAQUE;
+    td->ct_flags = CT_VOID;
     td->ct_flags_mut = 0;
+    td->ct_incomplete_struct_or_union = 1;
     td->ct_name_position = strlen("void");
     unique_key[0] = "void";
     return get_unique_type(td, unique_key, 1);
@@ -5167,9 +5171,9 @@ static PyObject *new_struct_or_union_type(const char *name, int flag)
 
     td->ct_size = -1;
     td->ct_length = -1;
-    // may be unset later if this type needs lazy init
-    td->ct_flags = flag | CT_IS_OPAQUE;
+    td->ct_flags = flag;
     td->ct_flags_mut = 0;
+    td->ct_incomplete_struct_or_union = 1;
     td->ct_extra = NULL;
     memcpy(td->ct_name, name, namelen + 1);
     td->ct_name_position = namelen;
@@ -5334,12 +5338,11 @@ static PyObject *b_complete_struct_or_union(PyObject *self, PyObject *args)
     Py_BEGIN_CRITICAL_SECTION(ct);
     is_union = ct->ct_flags & CT_UNION;
     if (!((ct->ct_flags & CT_UNION) || (ct->ct_flags & CT_STRUCT)) ||
-        !((ct->ct_flags & CT_IS_OPAQUE) || cffi_check_flag(ct->ct_under_construction))) {
+        !(cffi_check_flag(ct->ct_incomplete_struct_or_union) || cffi_check_flag(ct->ct_under_construction))) {
         PyErr_SetString(PyExc_TypeError,
                         "first arg must be a non-initialized struct or union ctype");
         goto finally;
     }
-    assert((ct->ct_flags & CT_IS_OPAQUE) ^ (ct->ct_under_construction));
     ct->ct_flags_mut &= ~(CT_CUSTOM_FIELD_POS | CT_WITH_PACKED_CHANGE);
 
     alignment = 1;
@@ -5368,7 +5371,8 @@ static PyObject *b_complete_struct_or_union(PyObject *self, PyObject *args)
             goto finally;
 
         if ((ftype->ct_flags & (CT_STRUCT | CT_UNION)) &&
-            !(ftype->ct_flags & CT_IS_OPAQUE)) {
+            !((ftype->ct_flags & CT_IS_OPAQUE) || cffi_check_flag(ct->ct_incomplete_struct_or_union))) {
+
             /* force now the type of the nested field */
             if (force_lazy_struct(ftype) < 0)
                 goto finally;
@@ -5666,7 +5670,7 @@ static PyObject *b_complete_struct_or_union(PyObject *self, PyObject *args)
 
     ct->ct_size = totalsize;
     ct->ct_length = totalalignment;
-    ct->ct_flags &= ~CT_IS_OPAQUE;
+    cffi_set_flag(ct->ct_incomplete_struct_or_union, 0);
 #ifdef Py_GIL_DISABLED
     /* use seq consistency at last after writing other fields
        to ensure other fields are visible to threads */
@@ -6135,6 +6139,8 @@ static PyObject *new_function_type(PyObject *fargs,   /* tuple */
         char *msg;
         if (fresult->ct_flags & CT_IS_OPAQUE)
             msg = "result type '%s' is opaque";
+        else if (cffi_check_flag(fresult->ct_incomplete_struct_or_union))
+            msg = "result type '%s' is not yet initialized";
         else if (cffi_check_flag(fresult->ct_under_construction))
             msg = "result type '%s' is under construction";
         else

--- a/src/c/misc_win32.h
+++ b/src/c/misc_win32.h
@@ -1,3 +1,6 @@
+#ifndef CFFI_MISC_WIN32_H
+#define CFFI_MISC_WIN32_H
+
 #include <malloc.h>   /* for alloca() */
 
 
@@ -301,3 +304,5 @@ static void cffi_atomic_store_uint8(uint8_t *ptr, uint8_t value)
 {
     _InterlockedExchange8(ptr, value);
 }
+
+#endif /* CFFI_MISC_WIN32_H */

--- a/src/c/realize_c_type.c
+++ b/src/c/realize_c_type.c
@@ -448,7 +448,7 @@ _realize_c_struct_or_union(builder_c_t *builder, int sindex)
             }
         }
         if (ct != NULL) {
-            cffi_set_flag(ct->ct_incomplete_struct_or_union, 0);
+            cffi_set_flag(ct->ct_unrealized_struct_or_union, 0);
         }
 
         LOCK_REALIZE();

--- a/src/c/realize_c_type.c
+++ b/src/c/realize_c_type.c
@@ -395,6 +395,8 @@ _realize_c_struct_or_union(builder_c_t *builder, int sindex)
 
         if (!(s->flags & _CFFI_F_EXTERNAL)) {
             int flags = (s->flags & _CFFI_F_UNION) ? CT_UNION : CT_STRUCT;
+            int is_opaque = (s->flags & _CFFI_F_OPAQUE);
+            flags |= is_opaque ? CT_IS_OPAQUE : 0;
             char *name = alloca(8 + strlen(s->name));
             _realize_name(name,
                           (s->flags & _CFFI_F_UNION) ? "union " : "struct ",
@@ -406,19 +408,17 @@ _realize_c_struct_or_union(builder_c_t *builder, int sindex)
             if (x == NULL)
                 return NULL;
 
-            if (!(s->flags & _CFFI_F_OPAQUE)) {
+            if (!is_opaque) {
                 assert(s->first_field_index >= 0);
                 ct = (CTypeDescrObject *)x;
                 ct->ct_size = (Py_ssize_t)s->size;
-                // unset opaque flag temporarily added in
-                // new_struct_or_union_type since _CFFI_F_OPAQUE isn't set
-                ct->ct_flags &= ~CT_IS_OPAQUE;
                 ct->ct_length = s->alignment; /* may be -1 */
                 ct->ct_lazy_field_list = 1;
                 ct->ct_extra = builder;
             }
-            else
+            else {
                 assert(s->first_field_index < 0);
+            }
         }
         else {
             assert(s->first_field_index < 0);
@@ -446,6 +446,9 @@ _realize_c_struct_or_union(builder_c_t *builder, int sindex)
                     return NULL;
                 }
             }
+        }
+        if (ct != NULL) {
+            cffi_set_flag(ct->ct_incomplete_struct_or_union, 0);
         }
 
         LOCK_REALIZE();


### PR DESCRIPTION
With this change `CT_IS_OPAQUE` is only ever set for functions that are specified to be opaque. Incomplete structs created via the python API have `ct_incomplete_struct_or_union` set and otherwise behave like opaque structs.

`ct_incomplete_struct_or_union` is only ever set for structs or unions. It is also unset once struct or union ctypes are set-up, whether or not they need lazy init.